### PR TITLE
Maria db 10.6.12

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ MariaDB4j CONTRIBUTORS
 - Gordon Little [@glittle1972](https://github.com/glittle1972), Jun 2019 Add option to force continue-on-error for sourcing SQL scripts
 - Theodore Ni [@tjni](https://github.com/tjni), Aug 2019 Reduce file copying during classpath unpacking
 - Tamas Gaspar [@tomlincoln](https://github.com/tomlincoln), Oct 2020 Make MariaDB4jService start method do not recreate the DB when already started
+- Knowles Atchison, Jr [@TheKnowles](https://github.com/TheKnowles), March 2023 Added MariaDB 10.6.12 to build
 - also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 
 Contributions, patches, forks more than welcome - hack it, and add your name here! ;-)

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
@@ -9,8 +9,9 @@
         <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
-	<artifactId>mariaDB4j-db-linux64</artifactId>
-	<version>10.6.12</version>
+    <groupId>dev.atchison.mariaDB4j</groupId>
+    <artifactId>mariaDB4j-db-linux64</artifactId>
+    <version>10.6.12</version>
 
     <properties>
         <mariaDB.version>${project.version}</mariaDB.version>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <artifactId>mariaDB4j-pom-lite</artifactId>
+        <version>2.2.1</version>
+        <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
+    </parent>
+
+	<artifactId>mariaDB4j-db-linux64</artifactId>
+	<version>10.6.12</version>
+
+    <properties>
+        <mariaDB.version>${project.version}</mariaDB.version>
+        <cacheDir>${project.basedir}/../../../tmpDir</cacheDir>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.build.directory}/generated-resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>generate-resources</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <property name="project.basedir" value="${project.basedir}"/>
+                                <property name="project.build.directory" value="${project.build.directory}"/>
+                                <property name="cacheDir" value="${cacheDir}"/>
+                                <property name="mariaDB.version" value="${mariaDB.version}"/>
+                                <ant antfile="${project.basedir}/prepare.xml">
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>                                 
+        </plugins>
+    </build>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/prepare.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/prepare.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<project name="MariaDB4J" default="extract" >
+    <description>
+        Ant task to download file from internet and extract during maven package
+    </description>
+
+    <target name="env">
+        <echo message="Project path   : ${project.basedir}"/>
+        <echo message="Output location: ${project.build.directory}"/>
+        <echo message="Cache location : ${cacheDir}"/>
+        <echo message="MariaDB version: ${mariaDB.version}"/>
+        <mkdir dir="${cacheDir}" />
+        <mkdir dir="${cacheDir}/input" />
+    </target>
+
+    <target name="download" depends="env"
+        description="Download linux tar.gz file from mariadb.com">
+        <echo message="Downloading linux MariaDB ${mariaDB.version} file ..." />
+        <get src="https://dlm.mariadb.com/2830105/MariaDB/mariadb-${mariaDB.version}/bintar-linux-systemd-x86_64/mariadb-${mariaDB.version}-linux-systemd-x86_64.tar.gz"
+            skipexisting="true"             
+            dest="${cacheDir}/input/mariadb-${mariaDB.version}-linux-x86_64.tar.gz" />
+    </target>
+
+    <target name="extract" depends="env,download"
+        description="Extract project files">
+        <echo message="Extracting tar.gz file" />
+        <untar src="${cacheDir}/input/mariadb-${mariaDB.version}-linux-x86_64.tar.gz" 
+                dest="${project.build.directory}"
+                compression="gzip"  />
+        <echo message="Copying share folders and files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64">
+                <include name="share/**/*"/>
+            </fileset>
+        </copy>
+        <echo message="Copying lib files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/libs">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/lib">
+                <include name="libmariadb.so*"/>
+                <include name="libmariadbclient*"/>
+                <include name="libmysql*"/>
+            </fileset>
+        </copy>
+        <!--- As of MariaDB 10.5.2, the original mysql* bins are sym links to mariadb equivalents.
+        Sym links do not work in jar files as they are not platform independent
+        We copy over the mariadb* names and the code has been updated to use these new binaries
+        https://jira.mariadb.org/browse/MDEV-21303
+        -->
+        <echo message="Copying bin files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/bin">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/bin">
+                <include name="mariadb"/>
+                <include name="mariadbd"/>
+                <include name="mariadb-check"/>
+                <include name="mariadb-dump"/>
+                <include name="my_print_defaults"/>
+                <include name="resolveip"/>
+            </fileset>
+        </copy>
+
+        <echo message="Copying scripts files" />
+        <copy file="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/scripts/mariadb-install-db"
+              tofile="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/scripts/mariadb-install-db">
+        </copy>
+
+        <chmod dir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/bin" perm="ugo+rx"
+                includes="*"/>                               
+    </target>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
@@ -9,7 +9,8 @@
         <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
-	<artifactId>mariaDB4j-db-winx64</artifactId>
+    <groupId>dev.atchison.mariaDB4j</groupId>
+    <artifactId>mariaDB4j-db-winx64</artifactId>
     <version>10.6.12</version>
 
     <properties>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <artifactId>mariaDB4j-pom-lite</artifactId>
+        <version>2.2.1</version>
+        <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
+    </parent>
+
+	<artifactId>mariaDB4j-db-winx64</artifactId>
+    <version>10.6.12</version>
+
+    <properties>
+        <mariaDB.version>${project.version}</mariaDB.version>
+        <cacheDir>${project.basedir}/../../../tmpDir</cacheDir>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.build.directory}/generated-resources</directory>
+            </resource>
+        </resources>
+        <plugins>         
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>generate-resources</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <property name="project.basedir" value="${project.basedir}"/>
+                                <property name="project.build.directory" value="${project.build.directory}"/>
+                                <property name="cacheDir" value="${cacheDir}"/>
+                                <property name="mariaDB.version" value="${mariaDB.version}"/>
+                                <ant antfile="${project.basedir}/prepare.xml">
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>        
+        </plugins>
+    </build>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/prepare.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/prepare.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<project name="MariaDB4J" default="extract" >
+    <description>
+        Ant task to download file from internet and extract during maven package
+    </description>
+
+    <target name="env">
+        <echo message="Project path   : ${project.basedir}"/>
+        <echo message="Output location: ${project.build.directory}"/>
+        <echo message="Cache location : ${cacheDir}"/>
+        <echo message="MariaDB version: ${mariaDB.version}"/>
+        <mkdir dir="${cacheDir}" />
+        <mkdir dir="${cacheDir}/input" />
+    </target>
+
+    <target name="download" depends="env"
+        description="Download Windows zip file from mariadb.com">
+        <echo message="Downloading Windows MariaDB ${mariaDB.version} file ..." />
+        <get src="https://dlm.mariadb.com/2830119/MariaDB/mariadb-${mariaDB.version}/winx64-packages/mariadb-${mariaDB.version}-winx64.zip"
+            skipexisting="true" 
+            dest="${cacheDir}/input/mariadb-${mariaDB.version}-winx64.zip" />
+    </target>
+
+    <!--- As of MariaDB 10.5.2, the original mysql* bins are sym links to mariadb equivalents.
+    Sym links do not work in jar files as they are not platform independent
+    We copy over the mariadb* names and the code has been updated to use these new binaries
+    https://jira.mariadb.org/browse/MDEV-21303
+    -->
+    <target name="extract" depends="env,download"
+        description="Extract project files">
+        <echo message="Extracting zip file" />
+        <unzip src="${cacheDir}/input/mariadb-${mariaDB.version}-winx64.zip" 
+                dest="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/winx64"
+                overwrite="true">
+            <patternset>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadbd.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-check.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-dump.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-install-db.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/my_print_defaults.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/share/**/*"/>
+            </patternset>
+            <mapper>
+                <globmapper from="mariadb-${mariaDB.version}-winx64/*" to="*"/>
+            </mapper>
+        </unzip>
+    </target>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/pom.xml
@@ -13,6 +13,7 @@
         <relativePath>../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
+    <groupId>dev.atchison.mariaDB4j</groupId>
     <artifactId>mariaDB4j-10.6.12-binaries</artifactId>
     <name>mariaDB4j 10.6.12 binaries</name>
     <!-- This artefact is never released, and just used in ../.travis.yml, so let's use a special marker version to make that clear -->

--- a/DBs/mariaDB4j-db-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/pom.xml
@@ -13,30 +13,15 @@
         <relativePath>../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
-    <artifactId>mariaDB4j-binaries</artifactId>
-    <name>mariaDB4j Platform binaries</name>
+    <artifactId>mariaDB4j-10.6.12-binaries</artifactId>
+    <name>mariaDB4j 10.6.12 binaries</name>
     <!-- This artefact is never released, and just used in ../.travis.yml, so let's use a special marker version to make that clear -->
     <version>0.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
-<!--        <module>mariaDB4j-db-win32-10.6.12</module>-->
-        <module>mariaDB4j-db-win32-10.2.11</module>
-        <module>mariaDB4j-db-win32-10.1.23</module>
-        <module>mariaDB4j-db-win32-10.1.20</module>
-        <module>mariaDB4j-db-win32-10.0.13</module>
-
-<!--        <module>mariaDB4j-db-mac64-10.6.12</module>-->
-	    <module>mariaDB4j-db-mac64-10.2.11</module>
-        <module>mariaDB4j-db-mac64-10.1.23</module>
-        <module>mariaDB4j-db-mac64-10.1.9</module>
-        <module>mariaDB4j-db-mac64-5.5.34</module>
-
-<!--        <module>mariaDB4j-db-linux64-10.6.12</module>-->
-        <module>mariaDB4j-db-linux64-10.2.11</module>
-        <module>mariaDB4j-db-linux64-10.1.23</module>
-        <module>mariaDB4j-db-linux64-10.1.13</module>
-
-	<module>mariaDB4j-db-10.3</module>
+        <module>mariaDB4j-db-linux64-10.6.12</module>
+        <!-- no support for osx, see PR commentary -->
+        <module>mariaDB4j-db-win64-10.6.12</module>
     </modules>
 </project>

--- a/DBs/pom.xml
+++ b/DBs/pom.xml
@@ -13,6 +13,7 @@
         <relativePath>../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
+    <groupId>dev.atchison.mariaDB4j</groupId>
     <artifactId>mariaDB4j-binaries</artifactId>
     <name>mariaDB4j Platform binaries</name>
     <!-- This artefact is never released, and just used in ../.travis.yml, so let's use a special marker version to make that clear -->
@@ -20,23 +21,8 @@
     <packaging>pom</packaging>
 
     <modules>
-<!--        <module>mariaDB4j-db-win32-10.6.12</module>-->
-        <module>mariaDB4j-db-win32-10.2.11</module>
-        <module>mariaDB4j-db-win32-10.1.23</module>
-        <module>mariaDB4j-db-win32-10.1.20</module>
-        <module>mariaDB4j-db-win32-10.0.13</module>
-
-<!--        <module>mariaDB4j-db-mac64-10.6.12</module>-->
-	    <module>mariaDB4j-db-mac64-10.2.11</module>
-        <module>mariaDB4j-db-mac64-10.1.23</module>
-        <module>mariaDB4j-db-mac64-10.1.9</module>
-        <module>mariaDB4j-db-mac64-5.5.34</module>
-
-<!--        <module>mariaDB4j-db-linux64-10.6.12</module>-->
-        <module>mariaDB4j-db-linux64-10.2.11</module>
-        <module>mariaDB4j-db-linux64-10.1.23</module>
-        <module>mariaDB4j-db-linux64-10.1.13</module>
-
-	<module>mariaDB4j-db-10.3</module>
+        <!-- Support for version prior to 10.5.2 are not supported -->
+        <module>mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12</module>
+        <module>mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12</module>
     </modules>
 </project>

--- a/DBs/readme.txt
+++ b/DBs/readme.txt
@@ -9,3 +9,6 @@ Technically if you really must then an Oracle mySQL distrib would work as well -
 
 Note that on OSX (at least) bin/mysql_install_db is a symlink to scripts/mysql_install_db, and you need to copy the
 file from scripts rather than the symlink.
+
+Starting with version 10.6.12 of maria, scripts pull down the binaries and package the contents into the jar for eventual 
+classpath evaluation at runtime.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
+# MariaDB4j
+
+This is a mostly hard fork of MariaDB4j to account for disconnects between Java 11/17 and Spring 5/6.  
+The last binary update that shipped with MariaDB4j out of the box was 10.2.11, released in 2017.  
+
+Using Spring 5/equivalent JPA there are SQL syntax problems that make version 2.6.0 unusable for modern development.  
+The only current way to get this to work is to use installed binaries on the host system.  
+This fork aims to create and maintain a 2.7.x release series to account for the above aforementioned issues.
+
+Linux support is tested. Windows support is simulated. OSX support is not provided.  
+Best effort will be made to maintain upstream updates as applicable.  
+
+Compatability Chart
+
+| MariaDB4j | Spring | MariaDB                     |
+|-----------|--------|-----------------------------|
+| 3.0.0     | 6      | 10.2.11 / Installed version |
+| 2.6.0     | 5      | 10.2.11 / Installed version |
+| 2.7.x     | 5      | 10.6.12+                    |
+
+There are breaking changes for 2.7.x that will NOT SUPPORT versions of MariaDB before 10.5.2.  
+
 What?
 =====
 
-_Please :star: Star on GitHub and **support me 🫶 through [a Tidelift subscription](https://tidelift.com)** to ensure active maintenance!_
-
 MariaDB4j is a Java (!) "launcher" for [MariaDB](http://mariadb.org) (the "backward compatible, drop-in replacement of the MySQL® Database Server", see [Wikipedia](http://en.wikipedia.org/wiki/MariaDB)), allowing you to use MariaDB (MySQL®) from Java without ANY installation / external dependencies.  Read again: You do NOT have to have MariaDB binaries installed on your system to use MariaDB4j!
-
-<span class="badge-paypal"><a href="https://www.paypal.me/MichaelVorburgerCH?locale.x=en_US" title="Donate to this project using Paypal"><img src="https://img.shields.io/badge/paypal-donate-yellow.svg" alt="PayPal donate button" /></a></span>
-[![Patreon me!](https://img.shields.io/badge/patreon-donate-yellow.svg)](https://www.patreon.com/vorburger)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/ch.vorburger.mariaDB4j/mariaDB4j/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ch.vorburger.mariaDB4j/mariaDB4j)
-[![Javadocs](http://www.javadoc.io/badge/ch.vorburger.mariaDB4j/mariaDB4j-core.svg)](http://www.javadoc.io/doc/ch.vorburger.mariaDB4j/mariaDB4j-core)
-[![JitPack](https://jitpack.io/v/vorburger/MariaDB4j.svg)](https://jitpack.io/#vorburger/MariaDB4j)
-[![Build Status](https://app.travis-ci.com/vorburger/MariaDB4j.svg?branch=main)](https://app.travis-ci.com/vorburger/MariaDB4j)
 
 How? (Java)
 ----

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ MariaDB4j JAR binaries are available from:
 <dependency>
     <groupId>ch.vorburger.mariaDB4j</groupId>
     <artifactId>mariaDB4j</artifactId>
-    <version>3.0.0</version>
+    <version>2.7.0</version>
 </dependency>
 ```
 
@@ -146,7 +146,7 @@ source; just git clone this and then mvn install or deploy. -- MariaDB4j's Maven
 <dependency>
     <groupId>ch.vorburger.mariaDB4j</groupId>
     <artifactId>mariaDB4j</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/mariaDB4j-app/pom.xml
+++ b/mariaDB4j-app/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>ch.vorburger.mariaDB4j</groupId>
+		<groupId>dev.atchison.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
 		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>

--- a/mariaDB4j-app/pom.xml
+++ b/mariaDB4j-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ch.vorburger.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <groupId>dev.atchison.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
         <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -109,7 +109,7 @@ public class DB {
         logger.info("Installing a new embedded database to: " + baseDir);
         File installDbCmdFile = configuration.getExecutable(Executable.InstallDB);
         ManagedProcessBuilder builder = new ManagedProcessBuilder(installDbCmdFile);
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysql_install_db"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb-install-db"));
         builder.getEnvironment().put(configuration.getOSLibraryEnvironmentVarName(), libDir.getAbsolutePath());
         builder.setWorkingDirectory(baseDir);
         if (!configuration.isWindows()) {
@@ -155,7 +155,7 @@ public class DB {
             mysqldProcess = startPreparation();
             ready = mysqldProcess.startAndWaitForConsoleMessageMaxMs(getReadyForConnectionsTag(), dbStartMaxWaitInMS);
         } catch (Exception e) {
-            logger.error("failed to start mysqld", e);
+            logger.error("failed to start mariadbd", e);
             throw new ManagedProcessException("An error occurred while starting the database", e);
         }
         if (!ready) {
@@ -174,7 +174,7 @@ public class DB {
 
     synchronized ManagedProcess startPreparation() throws ManagedProcessException, IOException {
         ManagedProcessBuilder builder = new ManagedProcessBuilder(configuration.getExecutable(Server));
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysqld"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadbd"));
         builder.getEnvironment().put(configuration.getOSLibraryEnvironmentVarName(), libDir.getAbsolutePath());
         builder.addArgument("--no-defaults"); // *** THIS MUST COME FIRST ***
         builder.addArgument("--console");
@@ -203,7 +203,7 @@ public class DB {
         // because cleanupOnExit() just installed our (class DB) own
         // Shutdown hook, we don't need the one from ManagedProcess:
         builder.setDestroyOnShutdown(false);
-        logger.info("mysqld executable: " + builder.getExecutable());
+        logger.info("mariadbd executable: " + builder.getExecutable());
         return builder.build();
     }
 
@@ -342,7 +342,7 @@ public class DB {
         logger.info("Running a " + logInfoText);
         try {
             ManagedProcessBuilder builder = new ManagedProcessBuilder(configuration.getExecutable(Client));
-            builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysql"));
+            builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb"));
             builder.setWorkingDirectory(baseDir);
             builder.addArgument("--default-character-set=utf8");
             if (username != null && !username.isEmpty()) {
@@ -485,7 +485,7 @@ public class DB {
 
         BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
         builder.addStdOut(outputStream);
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysqldump"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb-dump"));
         builder.addArgument("--port=" + configuration.getPort());
         if (!configuration.isWindows()) {
             builder.addFileArgument("--socket", getAbsoluteSocketFile());

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.SystemUtils;
  */
 public class DBConfigurationBuilder {
 
-    protected static final String WIN32 = "win32";
+    protected static final String WINX64 = "winx64";
     protected static final String LINUX = "linux";
     protected static final String OSX = "osx";
 
@@ -54,7 +54,7 @@ public class DBConfigurationBuilder {
     private String databaseVersion = null;
 
     // all these are just some defaults
-    protected String osDirectoryName = SystemUtils.IS_OS_WINDOWS ? WIN32 : SystemUtils.IS_OS_MAC ? OSX : LINUX;
+    protected String osDirectoryName = SystemUtils.IS_OS_WINDOWS ? WINX64 : SystemUtils.IS_OS_MAC ? OSX : LINUX;
     protected String baseDir = SystemUtils.JAVA_IO_TMPDIR + "/MariaDB4j/base";
     protected String libDir = null;
 
@@ -289,11 +289,11 @@ public class DBConfigurationBuilder {
     protected String _getDatabaseVersion() {
         String databaseVersion = getDatabaseVersion();
         if (databaseVersion == null) {
-            if (!OSX.equals(getOS()) && !LINUX.equals(getOS()) && !WIN32.equals(getOS())) {
+            if (!OSX.equals(getOS()) && !LINUX.equals(getOS()) && !WINX64.equals(getOS())) {
                 throw new IllegalStateException("OS not directly supported, please use setDatabaseVersion() to set the name "
                         + "of the package that the binaries are in, for: " + SystemUtils.OS_VERSION);
             }
-            databaseVersion = "mariadb-10.2.11";
+            databaseVersion = "mariadb-10.6.12";
         }
         return databaseVersion;
     }
@@ -368,23 +368,23 @@ public class DBConfigurationBuilder {
     }
 
     protected Map<Executable, Supplier<File>> _getExecutables() {
-        executables.putIfAbsent(Server, () -> new File(baseDir, "bin/mysqld" + getExtension()));
-        executables.putIfAbsent(Client, () -> new File(baseDir, "bin/mysql" + getExtension()));
-        executables.putIfAbsent(Dump, () -> new File(baseDir, "bin/mysqldump" + getExtension()));
+        executables.putIfAbsent(Server, () -> new File(baseDir, "bin/mariadbd" + getExtension()));
+        executables.putIfAbsent(Client, () -> new File(baseDir, "bin/mariadb" + getExtension()));
+        executables.putIfAbsent(Dump, () -> new File(baseDir, "bin/mariadb-dump" + getExtension()));
         executables.putIfAbsent(PrintDefaults, () -> new File(baseDir, "bin/my_print_defaults" + getExtension()));
         executables.putIfAbsent(InstallDB, () -> {
-            File bin = new File(baseDir, "bin/mysql_install_db" + getExtension());
+            File bin = new File(baseDir, "bin/mariadb-install-db" + getExtension());
             if (bin.exists()) {
                 return bin;
             }
-            return new File(baseDir, "scripts/mysql_install_db" + getExtension());
+            return new File(baseDir, "scripts/mariadb-install-db" + getExtension());
         });
 
         return executables;
     }
 
     public boolean isWindows() {
-        return WIN32.equals(getOS());
+        return WINX64.equals(getOS());
     }
 
     protected String getExtension() {

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -183,7 +183,7 @@ public class DBConfigurationBuilderTest {
     @Test public void defaultExecutables() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
-        assertTrue(config.getExecutable(Executable.Server).toString().contains("MariaDB4j/base/bin/mysqld"));
+        assertTrue(config.getExecutable(Executable.Server).toString().contains("MariaDB4j/base/bin/mariadbd"));
     }
 
     @Test public void customExecutables() {

--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <groupId>dev.atchison.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
         <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <groupId>dev.atchison.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
         <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>ch.vorburger.mariaDB4j</groupId>
+		<groupId>dev.atchison.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
 		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
@@ -21,12 +21,12 @@
 		</dependency>
 
 		<dependency>
-			<groupId>ch.vorburger.mariaDB4j</groupId>
+			<groupId>dev.atchison.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-linux64</artifactId>
 			<version>10.6.12</version>
 		</dependency>
 		<dependency>
-			<groupId>ch.vorburger.mariaDB4j</groupId>
+			<groupId>dev.atchison.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-winx64</artifactId>
 			<version>10.6.12</version>
 		</dependency>

--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ch.vorburger.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -23,18 +23,14 @@
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-linux64</artifactId>
-			<version>10.2.11</version>
+			<version>10.6.12</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
-			<artifactId>mariaDB4j-db-win32</artifactId>
-			<version>10.2.11</version>
+			<artifactId>mariaDB4j-db-winx64</artifactId>
+			<version>10.6.12</version>
 		</dependency>
-		<dependency>
-			<groupId>ch.vorburger.mariaDB4j</groupId>
-			<artifactId>mariaDB4j-db-mac64</artifactId>
-			<version>10.2.11</version>
-		</dependency>
+		<!-- no support for osx, see PR commentary -->
 		<dependency>
 			<!-- For MariaDB4jSpringService, only. This has to be repeated from mariaDB4j-core here
 			due to the optional true below -->

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -38,17 +38,21 @@ import org.junit.Test;
  */
 public class StartSimulatedForAllPlatformsTest {
 
-    @Test public void simulatedStartWin32() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.WIN32);
+    @Test public void simulatedStartWinx64() throws Exception {
+        checkPlatformStart(DBConfigurationBuilder.WINX64);
     }
 
     @Test public void simulatedStartLinux() throws Exception {
         checkPlatformStart(DBConfigurationBuilder.LINUX);
     }
 
-    @Test public void simulatedStartOSX() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.OSX);
-    }
+    // Commented out for 10.6.12 binary addition
+    // With the decommission of bintray in 2021 and the move of OCI images to GitHub Content Repo
+    // as docker images, it was impossible to unpack a version for DBs/.
+    // See additional commentary in the PR.
+//    @Test public void simulatedStartOSX() throws Exception {
+//        checkPlatformStart(DBConfigurationBuilder.OSX);
+//    }
 
     void checkPlatformStart(String platform) throws ManagedProcessException, IOException {
         DBConfigurationBuilder configBuilder = DBConfigurationBuilder.newBuilder();

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <relativePath>mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
+        <groupId>dev.atchison.mariaDB4j</groupId>
 	<artifactId>mariaDB4j-pom</artifactId>
 	<version>2.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-pom</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
     <scm>
@@ -43,6 +43,7 @@
 		 <springboot.version>2.7.5</springboot.version>
 		 <maven.compiler.source>11</maven.compiler.source>
 		 <maven.compiler.target>11</maven.compiler.target>
+		 <slf4j.version>2.0.6</slf4j.version>
 	</properties>
 
 	<build>
@@ -155,10 +156,15 @@
 	            <type>pom</type>
 	            <scope>import</scope>
 	        </dependency>
+			 <dependency>
+				 <groupId>org.slf4j</groupId>
+				 <artifactId>slf4j-api</artifactId>
+				 <version>${slf4j.version}</version>
+			 </dependency>
 	        <dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-simple</artifactId>
-	            <version>2.0.6</version>
+				<version>${slf4j.version}</version>
 	            <scope>test</scope>
 			</dependency>
             <dependency>


### PR DESCRIPTION
Initial commit of maria 10.6.12 binaries for deployment inclusion.

Breaking change to move to the mariadb* items in lieu of mysql*.

GroupId has been changed for every pom to avoid any confusion with original project for artifacts.