### PR TITLE
Add binlog capability to embedded deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ source; just git clone this and then mvn install or deploy. -- MariaDB4j's Maven
 <dependency>
     <groupId>dev.atchison.mariaDB4j</groupId>
     <artifactId>mariaDB4j</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.7.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Michael Vorburger
  * @author Michael Seaton
  * @author Gordon Little
+ * @author Knowles Atchison, Jr.
  */
 public class DB {
 
@@ -191,6 +192,10 @@ public class DB {
         } else {
             builder.addFileArgument("--datadir", dataDir.getCanonicalFile());
             builder.addFileArgument("--tmpdir", tmpDir.getCanonicalFile());
+        }
+        if (configuration.isBinLogEnabled()) {
+            builder.addArgument("--log-bin");
+            builder.addArgument("--binlog-format=row");
         }
         addPortAndMaybeSocketArguments(builder);
         for (String arg : configuration.getArgs()) {

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
@@ -111,6 +111,8 @@ public interface DBConfiguration {
      **/
     boolean isSecurityDisabled();
 
+    boolean isBinLogEnabled();
+
     String getURL(String dbName);
 
     String getDefaultCharacterSet();
@@ -137,13 +139,15 @@ public interface DBConfiguration {
         private final String defaultCharacterSet;
         private final ManagedProcessListener listener;
         private final boolean isSecurityDisabled;
+        private final boolean isBinLogEnabled;
+
         private final Function<String, String> getURL;
         private final Map<Executable, Supplier<File>> executables;
 
         Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String libDir, String dataDir, String tmpDir,
                 boolean isWindows, List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
                 boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL, String defaultCharacterSet,
-                Map<Executable, Supplier<File>> executables, ManagedProcessListener listener) {
+                Map<Executable, Supplier<File>> executables, ManagedProcessListener listener, boolean isBinLogEnabled) {
             this.port = port;
             this.socket = socket;
             this.binariesClassPathLocation = binariesClassPathLocation;
@@ -160,6 +164,7 @@ public interface DBConfiguration {
             this.defaultCharacterSet = defaultCharacterSet;
             this.listener = listener;
             this.executables = executables;
+            this.isBinLogEnabled = isBinLogEnabled;
         }
 
         @Override public int getPort() {
@@ -226,6 +231,10 @@ public interface DBConfiguration {
             return executables.getOrDefault(executable, () -> {
                 throw new IllegalArgumentException(executable.name());
             }).get();
+        }
+
+        @Override public boolean isBinLogEnabled() {
+            return isBinLogEnabled;
         }
     }
 }

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -67,6 +67,8 @@ public class DBConfigurationBuilder {
     protected List<String> args = new ArrayList<>();
     private boolean isSecurityDisabled = true;
 
+    private boolean isBinLogEnabled = false;
+
     private boolean frozen = false;
     private ManagedProcessListener listener;
 
@@ -207,7 +209,7 @@ public class DBConfigurationBuilder {
         return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), getLibDir(), _getDataDir(),
                 _getTmpDir(), isWindows(), _getArgs(), _getOSLibraryEnvironmentVarName(), isSecurityDisabled(),
                 isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getDefaultCharacterSet(), _getExecutables(),
-                getProcessListener());
+                getProcessListener(), isBinLogEnabled());
     }
 
     /**
@@ -224,6 +226,16 @@ public class DBConfigurationBuilder {
 
     public boolean isSecurityDisabled() {
         return isSecurityDisabled;
+    }
+
+    public DBConfigurationBuilder setBinLogEnabled(boolean binLogEnabled) {
+        checkIfFrozen("setBinLogEnabled");
+        this.isBinLogEnabled = binLogEnabled;
+        return this;
+    }
+
+    public boolean isBinLogEnabled() {
+        return isBinLogEnabled;
     }
 
     public DBConfigurationBuilder addArg(String arg) {


### PR DESCRIPTION
There is a now a toggle to enable the binary log to run within an embedded instance of MariaDB4j. This is useful for ecosystem components that might key off of this information to send change data capture events downstream.